### PR TITLE
💄 STYLE: 로그인 페이지 퍼블리싱

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -31,6 +31,7 @@ module.exports = {
 		'unused-imports/no-unused-imports-ts': ['error'],
 		'react/react-in-jsx-scope': 'off',
 		'react/no-unknown-property': ['error', { ignore: ['css'] }],
+		'@typescript-eslint/no-explicit-any': 'error',
 	},
 	overrides: [
 		{

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
 		"react": "^18.2.0",
 		"react-chartjs-2": "^5.2.0",
 		"react-dom": "^18.2.0",
+		"react-hook-form": "^7.51.1",
 		"react-icons": "^5.0.1",
 		"react-router-dom": "^6.22.3",
+		"zod": "^3.22.4",
 		"zustand": "^4.5.2"
 	},
 	"lint-staged": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"@chakra-ui/react": "^2.8.2",
 		"@emotion/react": "^11.11.4",
 		"@emotion/styled": "^11.11.0",
+		"@hookform/resolvers": "^3.3.4",
 		"@tanstack/react-query": "^5.28.4",
 		"@testboxlab/react-bubble-chart-d3": "^2.2.1",
 		"@types/d3": "^7.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   '@emotion/styled':
     specifier: ^11.11.0
     version: 11.11.0(@emotion/react@11.11.4)(@types/react@18.2.66)(react@18.2.0)
+  '@hookform/resolvers':
+    specifier: ^3.3.4
+    version: 3.3.4(react-hook-form@7.51.1)
   '@tanstack/react-query':
     specifier: ^5.28.4
     version: 5.28.4(react@18.2.0)
@@ -3034,6 +3037,14 @@ packages:
   /@fal-works/esbuild-plugin-global-externals@2.1.2:
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
     dev: true
+
+  /@hookform/resolvers@3.3.4(react-hook-form@7.51.1):
+    resolution: {integrity: sha512-o5cgpGOuJYrd+iMKvkttOclgwRW86EsWJZZRC23prf0uU2i48Htq4PuT73AVb9ionFyZrwYEITuOFGF+BydEtQ==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
+    dependencies:
+      react-hook-form: 7.51.1(react@18.2.0)
+    dev: false
 
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,12 +50,18 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-hook-form:
+    specifier: ^7.51.1
+    version: 7.51.1(react@18.2.0)
   react-icons:
     specifier: ^5.0.1
     version: 5.0.1(react@18.2.0)
   react-router-dom:
     specifier: ^6.22.3
     version: 6.22.3(react-dom@18.2.0)(react@18.2.0)
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
   zustand:
     specifier: ^4.5.2
     version: 4.5.2(@types/react@18.2.66)(react@18.2.0)
@@ -9528,6 +9534,15 @@ packages:
       use-sidecar: 1.1.2(@types/react@18.2.66)(react@18.2.0)
     dev: false
 
+  /react-hook-form@7.51.1(react@18.2.0):
+    resolution: {integrity: sha512-ifnBjl+kW0ksINHd+8C/Gp6a4eZOdWyvRv0UBaByShwU8JbVx5hTcTWEcd5VdybvmPTATkVVXk9npXArHmo56w==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /react-icons@5.0.1(react@18.2.0):
     resolution: {integrity: sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==}
     peerDependencies:
@@ -11082,6 +11097,10 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false
 
   /zustand@4.5.2(@types/react@18.2.66)(react@18.2.0):
     resolution: {integrity: sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import './App.css'
 
+import { ChakraProvider } from '@chakra-ui/react'
 import { ThemeProvider } from '@emotion/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider } from 'react-router-dom'
 
 import router from './app/routes/Routing'
-import GlobalStyles from './app/styles/global'
+import GlobalStyles, { ChakraGlobalStyles } from './app/styles/global'
 import theme from './app/styles/theme'
 import { worker } from './entities/mocks/borwser'
 
@@ -21,7 +22,9 @@ function App() {
 			<ThemeProvider theme={theme}>
 				<GlobalStyles />
 				<QueryClientProvider client={queryClient} />
-				<RouterProvider router={router} />
+				<ChakraProvider theme={ChakraGlobalStyles}>
+					<RouterProvider router={router} />
+				</ChakraProvider>
 			</ThemeProvider>
 		</div>
 	)

--- a/src/app/styles/global.tsx
+++ b/src/app/styles/global.tsx
@@ -1,21 +1,38 @@
+import { extendTheme } from '@chakra-ui/react'
 import { css, Global } from '@emotion/react'
 
 import { PALETTE } from './theme'
 
+const globalStyle = css`
+	body {
+		font-family: 'Noto Sans KR', sans-serif;
+		background-color: ${PALETTE['dark-600']};
+		color: white;
+	}
+
+	ul {
+		list-style: none;
+	}
+`
+
 const GlobalStyles = () => {
-	const globalStyle = css`
-		body {
-			font-family: 'Noto Sans KR', sans-serif;
-			background-color: ${PALETTE['dark-600']};
-			color: white;
-		}
-
-		ul {
-			list-style: none;
-		}
-	`
-
 	return <Global styles={globalStyle} />
 }
+
+export const ChakraGlobalStyles = extendTheme({
+	styles: {
+		global: {
+			html: { height: 'full' },
+			body: {
+				fontFamily: 'Noto Sans KR, sans-serif',
+				backgroundColor: `${PALETTE['dark-600']}`,
+				color: 'white',
+			},
+			ul: {
+				listStyle: 'none',
+			},
+		},
+	},
+})
 
 export default GlobalStyles

--- a/src/pages/sign-in/Page.tsx
+++ b/src/pages/sign-in/Page.tsx
@@ -6,10 +6,12 @@ import {
 	Input,
 } from '@chakra-ui/react'
 import { css } from '@emotion/react'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { Controller, SubmitHandler, useForm } from 'react-hook-form'
-import { z } from 'zod'
 
 import { BORDERRADIUS, FONTSIZE, FONTWEIGHT, PALETTE } from '@/app/styles/theme'
+
+import schema from './constants/schema'
 
 type SignInProps = {
 	email: string
@@ -21,11 +23,12 @@ function SignInPage() {
 		handleSubmit,
 		control,
 		formState: { errors, isSubmitting },
-	} = useForm<SignInProps>()
-
-	const authorizationSchema = z.object({
-		email: z.string(),
-		password: z.string(),
+	} = useForm<SignInProps>({
+		defaultValues: {
+			email: '',
+			password: '',
+		},
+		resolver: zodResolver(schema),
 	})
 
 	const onSubmit: SubmitHandler<SignInProps> = data => console.log(data)
@@ -69,6 +72,7 @@ function SignInPage() {
 				css={css({
 					width: '80%',
 				})}
+				noValidate
 			>
 				<Controller
 					name="email"
@@ -91,10 +95,11 @@ function SignInPage() {
 							{errors.email && (
 								<FormHelperText
 									css={css({
-										color: PALETTE['primary-700'],
+										color: PALETTE['pale-050'],
+										textAlign: 'left',
 									})}
 								>
-									이메일 유효성 검증 문구
+									{errors.email.message}
 								</FormHelperText>
 							)}
 						</FormControl>
@@ -121,10 +126,11 @@ function SignInPage() {
 							{errors.password && (
 								<FormHelperText
 									css={css({
-										color: PALETTE['primary-700'],
+										color: PALETTE['pale-050'],
+										textAlign: 'left',
 									})}
 								>
-									이메일 유효성 검증 문구
+									{errors.password.message}
 								</FormHelperText>
 							)}
 						</FormControl>

--- a/src/pages/sign-in/Page.tsx
+++ b/src/pages/sign-in/Page.tsx
@@ -1,5 +1,146 @@
+import {
+	Button,
+	FormControl,
+	FormHelperText,
+	FormLabel,
+	Input,
+} from '@chakra-ui/react'
+import { css } from '@emotion/react'
+import { Controller, SubmitHandler, useForm } from 'react-hook-form'
+import { z } from 'zod'
+
+import { BORDERRADIUS, FONTSIZE, FONTWEIGHT, PALETTE } from '@/app/styles/theme'
+
+type SignInProps = {
+	email: string
+	password: string
+}
+
 function SignInPage() {
-	return <div>로그인페이지</div>
+	const {
+		handleSubmit,
+		control,
+		formState: { errors, isSubmitting },
+	} = useForm<SignInProps>()
+
+	const authorizationSchema = z.object({
+		email: z.string(),
+		password: z.string(),
+	})
+
+	const onSubmit: SubmitHandler<SignInProps> = data => console.log(data)
+
+	return (
+		<div
+			css={css({
+				width: '500px',
+				height: '400px',
+				borderRadius: BORDERRADIUS.large,
+				backgroundColor: PALETTE['primary-900'],
+				display: 'flex',
+				flexDirection: 'column',
+				justifyContent: 'center',
+				alignItems: 'center',
+			})}
+		>
+			<div
+				css={css({
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'center',
+					padding: '20px 0',
+				})}
+			>
+				<div>
+					<img src="/logo.svg" alt="kernelsquare 로고" />
+				</div>
+				<div
+					css={css({
+						marginLeft: '5px',
+						fontWeight: FONTWEIGHT.bold,
+						fontSize: FONTSIZE.xlarge,
+					})}
+				>
+					KERNEL SQUARE
+				</div>
+			</div>
+			<form
+				onSubmit={handleSubmit(onSubmit)}
+				css={css({
+					width: '80%',
+				})}
+			>
+				<Controller
+					name="email"
+					control={control}
+					render={({ field }) => (
+						<FormControl
+							css={css({
+								marginBottom: '20px',
+							})}
+						>
+							<FormLabel>Email</FormLabel>
+							<Input
+								type="email"
+								{...field}
+								css={css({
+									background: PALETTE['pale-050'],
+									color: PALETTE['dark-600'],
+								})}
+							/>
+							{errors.email && (
+								<FormHelperText
+									css={css({
+										color: PALETTE['primary-700'],
+									})}
+								>
+									이메일 유효성 검증 문구
+								</FormHelperText>
+							)}
+						</FormControl>
+					)}
+				/>
+				<Controller
+					name="password"
+					control={control}
+					render={({ field }) => (
+						<FormControl
+							css={css({
+								marginBottom: '20px',
+							})}
+						>
+							<FormLabel>Password</FormLabel>
+							<Input
+								type="password"
+								{...field}
+								css={css({
+									background: PALETTE['pale-050'],
+									color: PALETTE['dark-600'],
+								})}
+							/>
+							{errors.password && (
+								<FormHelperText
+									css={css({
+										color: PALETTE['primary-700'],
+									})}
+								>
+									이메일 유효성 검증 문구
+								</FormHelperText>
+							)}
+						</FormControl>
+					)}
+				/>
+				<Button
+					mt={4}
+					colorScheme="teal"
+					isLoading={isSubmitting}
+					type="submit"
+				>
+					제출하기
+				</Button>
+			</form>
+		</div>
+	)
 }
 
 export default SignInPage

--- a/src/pages/sign-in/constants/schema.ts
+++ b/src/pages/sign-in/constants/schema.ts
@@ -1,0 +1,17 @@
+import * as z from 'zod'
+
+const schema = z.object({
+	email: z
+		.string()
+		.min(1, { message: '이메일 주소를 입력해주세요.' })
+		.email({ message: '이메일 형식에 맞추어 입력해주세요.' }),
+	password: z
+		.string()
+		.min(1, { message: '비밀번호를 입력해주세요.' })
+		.regex(/^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/, {
+			message:
+				'영문+숫자+특수문자(! @ # $ % & * ?) 조합 8~15자리를 입력해주세요.',
+		}),
+})
+
+export default schema

--- a/src/shared/layout/ui/Nav/Nav.tsx
+++ b/src/shared/layout/ui/Nav/Nav.tsx
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 import './nav.css'
 
 import { css } from '@emotion/react'


### PR DESCRIPTION
## 💡 관련 이슈

#### close: [#12 ](https://github.com/KernelSquare/f1-KernelSquare-admin-frontend/issues/12)

## 🌱 작업 개요

- [X] ✨ 새로운 기능 추가
- [X] 💄 페이지 스타일링
- [X] 🧹 기타 코드 수정, 의존성 추가

## 🔎 작업 상세

- 로그인 페이지 퍼블리싱을 완료했습니다.
- Chakra UI의 Form과 Input을 활용하여 퍼블리싱하였으며, React Hook Form의 Controller와 Zod를 사용하여 유효성 검증 및 입력을 처리하였습니다.

<img src="https://github.com/KernelSquare/f1-KernelSquare-admin-frontend/assets/123251211/4e535d60-0a78-49ad-956a-d46e4de89c25" width="50%"/>

## 💫 다음 할 일

- 대시보드 페이지 차트 그리기
- 테이블 사용 페이지들 퍼블리싱 결과 머지하기 

## ✔️ 체크리스트

- [x] dev 브랜치를 pull 받았나요?
