### PR TITLE
🐛 FIX: github actions jobs 통합

### DIFF
--- a/.github/workflows/admin-cicd.yaml
+++ b/.github/workflows/admin-cicd.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  build:
+  cicd:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,10 +27,6 @@ jobs:
           VITE_CRYPTO_KEY_LENGTH: ${{secrets.VITE_CRYPTO_KEY_LENGTH}}
         run: pnpm run build
 
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
## 💡 관련 이슈

#### close: [#20  ](https://github.com/KernelSquare/f1-KernelSquare-admin-frontend/issues/20)

## 🌱 작업 개요

- [x] 🐛 버그 수정

## 🔎 작업 상세

- github actions workflow에서 jobs의 분리로 S3에 빌드된 파일을 올릴 경로를 찾지 못하여 `cicd`라는 하나의 jobs로 취합하고자 합니다. 

## 💫 다음 할 일

- 대시보드 및 공지 페이지 API 연결 

## ✔️ 체크리스트

- [x] dev 브랜치를 pull 받았나요?
